### PR TITLE
Update FileModifier.py

### DIFF
--- a/SRC/core/FileModifier.py
+++ b/SRC/core/FileModifier.py
@@ -37,21 +37,29 @@ class FileModifier:
     def modify_hru_con(self, filter_ids):
         """
         Modifies HRU.con by setting specific ID rows to 1 and moving them to the top,
-        while preserving the exact format of all values.
+        while preserving the exact format of all values and retaining the original header.
         """
     
         path = os.path.join(self.txtinout_dir, "HRU.con")
     
-        # 1) Read with the first line as header
+        # Read the original file to preserve the header
+        with open(path, 'r') as file:
+            lines = file.readlines()
+    
+        # Separate header and data
+        header = lines[:1]  # Assuming the first line is the header
+        body = lines[1:]
+    
+        # Load the data into a DataFrame
         df = pd.read_csv(path, delim_whitespace=True, dtype=str, header=1)
     
-        # 2) Find the ID column (case‐insensitive)
+        # Find the ID column (case-insensitive)
         id_col = next((c for c in df.columns if c.lower() == 'id'), None)
         if not id_col:
             print("Error: No 'ID' column found in HRU.con.")
             return
     
-        # 3) Extract & modify the matching rows
+        # Extract & modify the matching rows
         modified_rows = []
         for fid in filter_ids:
             row = df[df[id_col] == str(fid)].copy()
@@ -61,21 +69,24 @@ class FileModifier:
             row[id_col] = '1'
             modified_rows.append(row)
     
-        # 4) Re‐assemble: modified rows at top, then the rest
+        # Re-assemble: modified rows at top, then the rest
         remaining = df[~df[id_col].isin(map(str, filter_ids))]
         out = pd.concat(modified_rows + [remaining], ignore_index=True)
     
-        # ** Replace NaN with empty strings to avoid issues **
+        # Replace NaN with empty strings to avoid issues
         out = out.fillna('')
     
-        # 5) Compute column widths (cast all cells to str to avoid float‐len issues)
+        # Compute column widths (cast all cells to str to avoid float-len issues)
         column_widths = [
             max(len(col), out[col].astype(str).map(len).max())
             for col in out.columns
         ]
     
-        # 6) Write back, preserving formatting
+        # Write back, preserving the original header
         with open(path, 'w') as f:
+            # Write the original header
+            f.writelines(header)
+            # Write the updated data
             f.write(' '.join(out.columns) + '\n')
             for _, row in out.iterrows():
                 parts = row.astype(str).tolist()
@@ -87,48 +98,60 @@ class FileModifier:
     def modify_object_cnt(self, hru_count):
         """
         Modify object.cnt by setting specific columns to reflect the number of HRUs,
-        while preserving the exact format of all values.
+        while preserving the exact format of all values and retaining the original header.
         """
+    
         path = os.path.join(self.txtinout_dir, "object.cnt")
-
-        # 1) Read with the first line as header
+    
+        # Read the original file to preserve the header
+        with open(path, 'r') as file:
+            lines = file.readlines()
+    
+        # Separate header and data
+        header = lines[:1]  # Assuming the first line is the header
+        body = lines[1:]
+    
+        # Load the data into a DataFrame
         df = pd.read_csv(path, delim_whitespace=True, dtype=str, header=1)
-
-        # 2) Find the NAME column
+    
+        # Find the NAME column
         name_col = next((c for c in df.columns if c.lower() == 'name'), None)
         if not name_col:
             print("Error: No 'NAME' column found in object.cnt.")
             return
         obj_name = df[name_col].iloc[0]
-
-        # 3) Prepare updates
+    
+        # Prepare updates
         zero_fields = [
-            'LHRU','RTU','GWFL','AQU','CHA','RES','REC',
-            'EXCO','DEL','CAN','PMP','OUT','LCHA','AQU2D','HRD','WRO'
+            'LHRU', 'RTU', 'GWFL', 'AQU', 'CHA', 'RES', 'REC',
+            'EXCO', 'DEL', 'CAN', 'PMP', 'OUT', 'LCHA', 'AQU2D', 'HRD', 'WRO'
         ]
         updates = {'OBJ': str(hru_count), 'HRU': str(hru_count)}
         updates.update({k: '0' for k in zero_fields})
-
-        # 4) Apply updates row‐wise
+    
+        # Apply updates row-wise
         for key, val in updates.items():
             col = next((c for c in df.columns if c.lower() == key.lower()), None)
             if col:
                 df.loc[df[name_col] == obj_name, col] = val
-
-        # 5) Compute column widths
+    
+        # Compute column widths
         column_widths = [
             max(len(col), df[col].astype(str).map(len).max())
             for col in df.columns
         ]
-
-        # 6) Write back
+    
+        # Write back, preserving the original header
         with open(path, 'w') as f:
+            # Write the original header
+            f.writelines(header)
+            # Write the updated data
             f.write(' '.join(df.columns) + '\n')
             for _, row in df.iterrows():
                 parts = row.astype(str).tolist()
                 line = ' '.join(val.rjust(w) for val, w in zip(parts, column_widths))
                 f.write(line + '\n')
-
+    
         print("object.cnt updated successfully.")
 
     def modify_file_cio(self, parameters_to_nullify=None):


### PR DESCRIPTION
This pull request enhances the functionality of the `FileModifier` class by ensuring that the original headers of files are preserved during modifications. The changes primarily focus on improving the handling of headers in the `modify_hru_con` and `modify_object_cnt` methods.

### Enhancements to header handling:

* [`SRC/core/FileModifier.py`](diffhunk://#diff-7feebc6a6cd85e5baf6083ee3f610c22ca10eb61291384159b987593e8a2e104L40-R62): Updated the `modify_hru_con` method to explicitly read and preserve the original header of the `HRU.con` file when modifying its content. The header is written back to the file along with the updated data. [[1]](diffhunk://#diff-7feebc6a6cd85e5baf6083ee3f610c22ca10eb61291384159b987593e8a2e104L40-R62) [[2]](diffhunk://#diff-7feebc6a6cd85e5baf6083ee3f610c22ca10eb61291384159b987593e8a2e104L64-R89)
* [`SRC/core/FileModifier.py`](diffhunk://#diff-7feebc6a6cd85e5baf6083ee3f610c22ca10eb61291384159b987593e8a2e104L90-R148): Updated the `modify_object_cnt` method to similarly preserve the original header of the `object.cnt` file during modifications. The header is retained and written back alongside the modified data.